### PR TITLE
SEKAI{2022_end}

### DIFF
--- a/data/contestsData.ts
+++ b/data/contestsData.ts
@@ -31,7 +31,7 @@ const contestsData: ContestData[] = [
     name: 'STACK The Flags 2022 Open',
     ctfPoints: 21600,
     writeupTag: 'stack-the-flags-2022',
-    ctftimeRating: NaN,
+    ctftimeRating: 0.0,
     year: 2022,
   },
   {

--- a/data/contestsData.ts
+++ b/data/contestsData.ts
@@ -10,6 +10,22 @@ export interface ContestData {
 
 const contestsData: ContestData[] = [
   {
+    place: 1,
+    ctftimeId: 1787,
+    name: 'X-MAS CTF 2022',
+    ctfPoints: 11024,
+    ctftimeRating: 48.84,
+    year: 2022,
+  },
+  {
+    place: 10,
+    ctftimeId: 1810,
+    name: 'KITCTFCTF 2022',
+    ctfPoints: 5270,
+    ctftimeRating: 13.491,
+    year: 2022,
+  },
+  {
     place: 3,
     ctftimeId: 1802,
     name: 'STACK The Flags 2022 Open',


### PR DESCRIPTION
Finalize 2022 CTF events.

@blueset Can we do a summary for 2022 event results? Can be a graph or image, showing how many top3/wins, out of how many events participated.. Planning to do a year review on Twitter official account. :)