### PR TITLE
SEKAI{ContestCardUpdate}

### DIFF
--- a/components/ContestCard.tsx
+++ b/components/ContestCard.tsx
@@ -11,6 +11,7 @@ const ContestCard = ({
   ctfPoints,
   ctftimeRating,
   writeupTag,
+  isMerger,
 }: ContestData) => {
   const [open, setOpen] = useState(false)
 
@@ -61,12 +62,17 @@ const ContestCard = ({
             )}
           </h2>
           <p className="flex flex-col items-start gap-2 mb-3 text-gray-500 xl:flex-row max-w-none dark:text-gray-400">
+            {ctftimeRating !== undefined && (
+              <span className="inline-block px-3 py-1 text-white bg-green-800 rounded-full">
+                Rating: {isNaN(ctftimeRating) ? 'Pending' : ctftimeRating.toFixed(2)}
+              </span>
+            )}
             <span className="inline-block px-3 py-1 text-white rounded-full bg-sky-800">
               Points: {ctfPoints}
             </span>
-            {ctftimeRating !== undefined && (
-              <span className="inline-block px-3 py-1 text-white bg-green-800 rounded-full">
-                Rating: {isNaN(ctftimeRating) ? 'Pending' : ctftimeRating}
+            {isMerger && (
+              <span className="inline-block px-3 py-1 text-white bg-cyan-800 rounded-full">
+                Merger
               </span>
             )}
           </p>

--- a/components/Splashscreen.tsx
+++ b/components/Splashscreen.tsx
@@ -45,6 +45,7 @@ const Splashscreen = () => {
   const splashRef = useRef(null)
   const lineContainerRef = useRef(null)
   const titleRef = useRef(null)
+
   useEffect(() => {
     if (splashRef.current) {
       const { lyrics, title } = sample(splashData)
@@ -83,7 +84,7 @@ const Splashscreen = () => {
       lang="ja"
       ref={splashRef}
       style={{ fontFeatureSettings: "'palt' 1" }}
-      className="fixed inset-0 flex items-center justify-center hidden transition-all duration-1000 bg-slate-900"
+      className="fixed inset-0 flex items-center justify-center transition-all duration-1000 bg-slate-900"
     >
       <button className="absolute top-0 right-0 p-4" onClick={() => hideSplash(splashRef.current)}>
         Skip

--- a/data/contestsData.ts
+++ b/data/contestsData.ts
@@ -5,7 +5,7 @@ export interface ContestData {
   ctfPoints: number
   ctftimeRating?: number
   writeupTag?: string
-  merger?: boolean
+  isMerger?: boolean
   year: number
 }
 
@@ -17,7 +17,7 @@ const contestsData: ContestData[] = [
     writeupTag: 'real-world-ctf-6th',
     ctfPoints: 2171,
     ctftimeRating: 124.224,
-    merger: true,
+    isMerger: true,
     year: 2024,
   },
   {
@@ -60,7 +60,7 @@ const contestsData: ContestData[] = [
     name: 'SECCON CTF 2023 International Finals',
     ctfPoints: 1990,
     ctftimeRating: 18.711,
-    merger: true,
+    isMerger: true,
     year: 2023,
   },
   {
@@ -69,7 +69,7 @@ const contestsData: ContestData[] = [
     name: 'niteCTF 2023',
     ctfPoints: 13556,
     ctftimeRating: 48,
-    merger: true,
+    isMerger: true,
     year: 2023,
   },
   {
@@ -78,7 +78,7 @@ const contestsData: ContestData[] = [
     name: 'BackdoorCTF 2023',
     ctfPoints: 21489,
     ctftimeRating: 68,
-    merger: true,
+    isMerger: true,
     year: 2023,
   },
   {
@@ -87,7 +87,7 @@ const contestsData: ContestData[] = [
     name: 'The Cyber Cooperative CTF',
     ctfPoints: 7700,
     ctftimeRating: 48.42,
-    merger: true,
+    isMerger: true,
     year: 2023,
   },
   {
@@ -144,7 +144,7 @@ const contestsData: ContestData[] = [
     name: '0CTF/TCTF 2023',
     ctfPoints: 6825,
     ctftimeRating: 67.786,
-    merger: true,
+    isMerger: true,
     year: 2023,
   },
   {
@@ -153,7 +153,7 @@ const contestsData: ContestData[] = [
     name: 'HITCON CTF 2023 Final',
     ctfPoints: 10710,
     ctftimeRating: 35.357,
-    merger: true,
+    isMerger: true,
     year: 2023,
   },
   {
@@ -162,7 +162,7 @@ const contestsData: ContestData[] = [
     name: 'RuCTF 2023',
     ctfPoints: 400732,
     ctftimeRating: 81.809,
-    merger: true,
+    isMerger: true,
     year: 2023,
   },
   {
@@ -205,7 +205,7 @@ const contestsData: ContestData[] = [
     name: 'SECCON CTF 2023 Quals',
     ctfPoints: 3157,
     ctftimeRating: 82.134,
-    merger: true,
+    isMerger: true,
     year: 2023,
   },
   {
@@ -238,7 +238,7 @@ const contestsData: ContestData[] = [
     name: 'WACON 2023 Final',
     ctfPoints: 3776,
     ctftimeRating: 19.039,
-    merger: true,
+    isMerger: true,
     year: 2023,
   },
   {
@@ -247,7 +247,7 @@ const contestsData: ContestData[] = [
     name: 'WACON 2023 Prequal',
     ctfPoints: 4115,
     ctftimeRating: 49.58,
-    merger: true,
+    isMerger: true,
     year: 2023,
   },
   {
@@ -256,7 +256,7 @@ const contestsData: ContestData[] = [
     name: 'Balsn CTF 2023',
     ctfPoints: 4878,
     ctftimeRating: 158.18,
-    merger: true,
+    isMerger: true,
     year: 2023,
   },
   {
@@ -265,7 +265,7 @@ const contestsData: ContestData[] = [
     name: 'HITCON CTF 2023 Quals',
     ctfPoints: 4586,
     ctftimeRating: 76.234,
-    merger: true,
+    isMerger: true,
     year: 2023,
   },
   {
@@ -375,7 +375,7 @@ const contestsData: ContestData[] = [
     name: 'Cyber Apocalypse 2023: The Cursed Mission',
     ctfPoints: 23125,
     ctftimeRating: 29.013,
-    merger: true,
+    isMerger: true,
     year: 2023,
   },
   {
@@ -384,7 +384,7 @@ const contestsData: ContestData[] = [
     name: 'DEF CON CTF Qualifier 2023',
     ctfPoints: 2083,
     ctftimeRating: 47.485,
-    merger: true,
+    isMerger: true,
     year: 2023,
   },
   {
@@ -409,7 +409,7 @@ const contestsData: ContestData[] = [
     name: 'PlaidCTF 2023',
     ctfPoints: 2598,
     ctftimeRating: 102.599,
-    merger: true,
+    isMerger: true,
     year: 2023,
   },
   {
@@ -418,7 +418,7 @@ const contestsData: ContestData[] = [
     name: 'Hack-A-Sat 4 Qualifiers',
     ctfPoints: 2433,
     ctftimeRating: 31.996,
-    merger: true,
+    isMerger: true,
     year: 2023,
   },
   {


### PR DESCRIPTION
- Rename `merger` to `isMerger` in `ContestData` interface
- Add Merger badge to `ContestCard`:

![image](https://github.com/project-sekai-ctf/sekai.team/assets/71956291/ebcc7df9-9f17-419c-bce2-447a25427b4b)

- Small unrelated fix in `Splashscreen`: redundant `hidden` Tailwind tag